### PR TITLE
Match cached files

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+const { extname } = require("path")
 const fs = require('fs').promises
 const { compileTemplate } = require('@vue/compiler-sfc')
 
@@ -7,7 +8,7 @@ module.exports = function () {
     enforce: 'pre',
 
     async load (id) {
-      if (!id.endsWith('.svg')) {
+      if (!extname(id).startsWith('.svg')) {
         return null
       }
 

--- a/index.js
+++ b/index.js
@@ -2,17 +2,19 @@ const { extname } = require("path")
 const fs = require('fs').promises
 const { compileTemplate } = require('@vue/compiler-sfc')
 
-module.exports = function () {
+export default function () {
   return {
     name: 'svg-loader',
     enforce: 'pre',
 
     async load (id) {
-      if (!extname(id).startsWith('.svg')) {
+      const path = id.split("?")[0]
+
+      if (!extname(path).startsWith('.svg')) {
         return null
       }
-
-      const svg = await fs.readFile(id, 'utf-8')
+      
+      const svg = await fs.readFile(path, 'utf-8')
 
       const { code } = compileTemplate({
         id: JSON.stringify(id),

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const { extname } = require("path")
 const fs = require('fs').promises
 const { compileTemplate } = require('@vue/compiler-sfc')
 
-export default function () {
+module.exports = function () {
   return {
     name: 'svg-loader',
     enforce: 'pre',

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ export default function () {
       if (!extname(path).startsWith('.svg')) {
         return null
       }
-      
+
       const svg = await fs.readFile(path, 'utf-8')
 
       const { code } = compileTemplate({


### PR DESCRIPTION
The plug-in doesn't handle module files because Vite was pushing parameters in the file id for caching.

```js
import icon from "@module/svg/icon.svg" //-> "@module/svg/icon.svg?v=f02481eb"
```