### PR TITLE
feat: Return path if import has parameter url

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,9 @@ module.exports = function svgLoader () {
 
     async load (id) {
       const path = id.split('?')[0]
+      const parameter = id.split('?')[1]
 
-      if (!extname(path).startsWith('.svg')) {
+      if (!extname(path).startsWith('.svg') || parameter === 'url') {
         return null
       }
 

--- a/index.js
+++ b/index.js
@@ -8,8 +8,7 @@ module.exports = function svgLoader () {
     enforce: 'pre',
 
     async load (id) {
-      const path = id.split('?')[0]
-      const parameter = id.split('?')[1]
+      const [path, parameter] = id.split('?')
 
       if (!extname(path).startsWith('.svg') || parameter === 'url') {
         return null


### PR DESCRIPTION
If the import has parameter `url`, return `null` to fallback to the default behaviour of returning path to the image so it can be used for example as an src to img tag.

```typescript
import Image from '@/assets/images/example.svg?url';
``` 

Resolves #11 