### PR TITLE
fix export default for CommonJS requiring

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,3 +31,4 @@ module.exports = function svgLoader (options = {}) {
     }
   }
 }
+module.exports.default = module.exports


### PR DESCRIPTION
case: `const { default: svgLoader } = require('vite-svg-loader')`