### PR TITLE
Fix attributes inheritance

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports = function svgLoader (options = {}) {
         transformAssetUrls: false
       })
 
-      return `${code}\nexport default render`
+      return `${code}\nexport default { render: render }`
     }
   }
 }


### PR DESCRIPTION
For some reason, if you just return render function (and not JS object as a component),
attribute inheritance doesn't work.

Fix it by returning a normal Vue component with `render` function instead of a plain `render` function

Fixes https://github.com/jpkleemans/vite-svg-loader/issues/29