### PR TITLE
Specify the right type for the "svgoConfig" option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 declare module 'vite-svg-loader' {
   import { Plugin } from 'vite'
-  function svgLoader(options?: { svgoConfig?: Object, svgo?: boolean }): Plugin
+  function svgLoader(options?: { svgoConfig?: import('svgo').OptimizeOptions, svgo?: boolean }): Plugin
   export default svgLoader
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 declare module 'vite-svg-loader' {
   import { Plugin } from 'vite'
-  function svgLoader(options?: { svgoConfig?: import('svgo').OptimizeOptions, svgo?: boolean }): Plugin
+  import { OptimizeOptions } from 'svgo'
+  function svgLoader(options?: { svgoConfig?: OptimizeOptions, svgo?: boolean }): Plugin
   export default svgLoader
 }
 


### PR DESCRIPTION
The type of the `svgoConfig` option is currently just `Object`, which doesn't provide proper type-safety for those who are using TypeScript, I changed the type to SVGO's `OptimizeOptions`.