### PR TITLE
Modified isRootRef to use monorepo

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,9 @@ module.exports = function svgLoader (options = {}) {
     },
 
     async load (id) {
-      const isRootRef = viteConfig.command === 'build' && !id.startsWith(viteConfig.root)
+      const root = viteConfig.root;
+      const parentDir = root.slice(0,root.lastIndexOf('/'));
+      const isRootRef = viteConfig.command === 'build' && !id.startsWith(parentDir);
 
       if (!id.match(svgRegex) || isRootRef) {
         return


### PR DESCRIPTION
There is a problem using the plugin in a monorepo environment.
svg files do not run on the plugin because the isRootRef value is true when referring to the svg file in a different directory.

If there is no issue, I hope the pull request will be accepted. thank you

```
error
index.45b22a28.js:4 DOMException: Failed to execute 'createElement' on 'Document': The tag name provided ('/assets/icn_arrow_up.a3b33b67.svg') is not a valid name.

project/pacakge-common/src/asset/svg/common.svg - is not coverted
project/pacakge-a/src/asset/svg/a.svg - is converted well
project/pacakge-a/index.html
```