### PR TITLE
fix: add name to components

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const fs = require('fs').promises
 const { compileTemplate } = require('@vue/compiler-sfc')
 const { optimize: optimizeSvg } = require('svgo')
+const { basename } = require('path')
 
 module.exports = function svgLoader (options = {}) {
   const { svgoConfig, svgo, defaultImport } = options
@@ -51,7 +52,14 @@ module.exports = function svgLoader (options = {}) {
         transformAssetUrls: false
       })
 
-      return `${code}\nexport default { render: render }`
+      const [, match] = basename(path).match(/(.*)\.svg$/)
+      const filename = match.replaceAll('"', '\\"')
+
+      return `${code}
+
+const component = { "${filename}": () => render() }["${filename}"]
+
+export default component`
     }
   }
 }


### PR DESCRIPTION
The components created by using the `?component` flag are anonymous.
This sets the components name to the filename.

Additionally, it reverts the changes made in #32. While attribute inheritance might have been broken then, that's not the case anymore. The changes in #32 also made it incompatible with the type definitions. Now it is more inline with  `FunctionalComponent` again.