### PR TITLE
Removing check that matches regex 

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,10 +12,6 @@ module.exports = function svgLoader (options = {}) {
     enforce: 'pre',
 
     async load (id) {
-      if (!id.match(svgRegex)) {
-        return
-      }
-
       const [path, query] = id.split('?', 2)
 
       const importType = query || defaultImport


### PR DESCRIPTION
This way any non-predefined value just defaults to the defaultImport. 
Returning undefined isn't really helping the user in any case and probably locks out any legacy svg imports that would like to use vite-svg-loader but cant change their query params because of backwards compatibility.

resolves https://github.com/jpkleemans/vite-svg-loader/issues/99 