### PR TITLE
Added configuration to preserve ViewBox attribute in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ svgLoader({
 })
 ```
 
-By default, SVGO does not preserve the viewBox attribute for optimization reasons. This can cause issues when you need to resize your SVG with CSS. You can pass options to `svgLoader()` to disable the removal of the `viewBox` attribute.
+By default, SVGO does not preserve the `viewBox` attribute for optimization reasons. This can cause issues when you need to resize your SVG with CSS. You can pass options to `svgLoader()` to disable the removal of the `viewBox` attribute.
 
 ```js
 svgLoader({

--- a/README.md
+++ b/README.md
@@ -76,6 +76,27 @@ svgLoader({
 })
 ```
 
+By default, SVGO does not preserve the viewBox attribute for optimization reasons. This can cause issues when you need to resize your SVG with CSS. You can pass options to `svgLoader()` to disable the removal of the `viewBox` attribute.
+
+```js
+svgLoader({
+  svgoConfig: {
+    multipass: true,
+    plugins: [
+      {
+        name: 'preset-default',
+        params: {
+          overrides: {
+            // @see https://github.com/svg/svgo/issues/1128
+            removeViewBox: false,
+          },
+        },
+      },
+    ],
+  },
+}),
+```
+
 ### Disable SVGO
 #### `vite.config.js`
 ```js


### PR DESCRIPTION
By default, SVGO does not preserve the viewBox attribute for optimization reasons. This can cause issues when you need to resize your SVG with CSS. This pull request proposes to add a code snippet showing the configuration to preserve the viewBox attribute.