### PR TITLE
ESM imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
-const fs = require('fs').promises
-const { compileTemplate } = require('vue/compiler-sfc')
-const { optimize: optimizeSvg } = require('svgo')
+import fs from 'fs/promises'
+import { optimize as optimizeSvg } from 'svgo'
+import { compileTemplate } from 'vue/compiler-sfc'
 
-module.exports = function svgLoader (options = {}) {
+function svgLoader (options = {}) {
   const { svgoConfig, svgo, defaultImport } = options
 
   const svgRegex = /\.svg(\?(raw|component|skipsvgo))?$/
@@ -59,4 +59,4 @@ module.exports = function svgLoader (options = {}) {
   }
 }
 
-module.exports.default = module.exports
+export default svgLoader

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-svg-loader",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Vite plugin to load SVG files as Vue components",
   "keywords": [
     "vite",
@@ -17,7 +17,8 @@
     "standard": "^16.0.3"
   },
   "peerDependencies": {
-    "vue": ">=3.2.13"
+    "vue": ">=3.2.13",
+    "vite": ">=5"
   },
   "scripts": {
     "lint": "standard --fix",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "standard": "^16.0.3"
   },
   "peerDependencies": {
-    "vue": ">=3.2.13",
-    "vite": ">=5"
+    "vue": ">=3.2.13"
   },
   "scripts": {
     "lint": "standard --fix",


### PR DESCRIPTION
Use ESM imports for compatibility with vite 5
https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated