### PR TITLE
Revert ESM imports

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -19,7 +19,7 @@
       }
     },
     "..": {
-      "version": "5.0.1",
+      "version": "5.1.0",
       "license": "MIT",
       "dependencies": {
         "svgo": "^3.0.2"

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
-import fs from 'fs/promises'
-import { optimize as optimizeSvg } from 'svgo'
-import { compileTemplate } from 'vue/compiler-sfc'
+const fs = require('fs').promises
+const { compileTemplate } = require('vue/compiler-sfc')
+const { optimize: optimizeSvg } = require('svgo')
 
-function svgLoader (options = {}) {
+module.exports = function svgLoader (options = {}) {
   const { svgoConfig, svgo, defaultImport } = options
 
   const svgRegex = /\.svg(\?(raw|component|skipsvgo))?$/
@@ -59,4 +59,4 @@ function svgLoader (options = {}) {
   }
 }
 
-export default svgLoader
+module.exports.default = module.exports

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-svg-loader",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-svg-loader",
-      "version": "5.0.1",
+      "version": "5.1.0",
       "license": "MIT",
       "dependencies": {
         "svgo": "^3.0.2"

--- a/package.json
+++ b/package.json
@@ -1,13 +1,12 @@
 {
   "name": "vite-svg-loader",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "description": "Vite plugin to load SVG files as Vue components",
   "keywords": [
     "vite",
     "vue",
     "svg"
   ],
-  "type": "module",
   "main": "./index.js",
   "types": "./index.d.ts",
   "dependencies": {


### PR DESCRIPTION
It isn't needed for Vite 5 and fixes compatibility issues with Vite 4