### PR TITLE
Add readme section about integrating with Nuxt

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,19 @@ import IconWithoutOptimizer from './my-icon.svg?skipsvgo'
 // <IconWithoutOptimizer />
 ```
 
+### Use with Nuxt
+Using `vite-svg-loader` with Nuxt is easy, we just need to set the following in `nuxt.config.js`.
+
+```js
+export default defineNuxtConfig({
+  vite: {
+    plugins: [svgLoader()]
+  }
+})
+```
+
+Or you can use `nuxt-svgo-loader`, which integrates `vite-svg-loader` and also uses Nuxt Devtools to enhance the development experience and help you find the SVG files you want in your project.
+
 ### Use with TypeScript
 If you use the loader in a Typescript project, you'll need to reference the type definitions inside `vite-env.d.ts`:
 ```ts


### PR DESCRIPTION
More and more people are integrating `vite-svg-loader` with Nuxt in their projects. To assist users in setting this up quickly, we could consider providing a clear configuration guide in the readme.

Additionally, I'd like to introduce [`nuxt-svgo-loader`](https://github.com/Mini-ghost/nuxt-svgo-loader), a Nuxt module built on `vite-svg-loader`. It's integrated with Nuxt Devtools, which aids users in locating the required SVG files in their projects.

![Nuxt SVGO loader with Nuxt Devtools](https://github.com/jpkleemans/vite-svg-loader/assets/39984251/d095099b-830a-4fef-9ba8-591f5d3e6b24)
