### PR TITLE
Base64 output and class parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,19 +8,22 @@ const debug = _debug('vite-svg-loader')
 module.exports = function svgLoader (options = {}) {
   const { svgoConfig, svgo, defaultImport } = options
 
-  const svgRegex = /\.svg(\?(raw|component|skipsvgo))?$/
+  const svgRegex = /\.svg(\?(raw|component|skipsvgo|base64))?(\=([a-z]+))?$/
 
   return {
     name: 'svg-loader',
     enforce: 'pre',
 
     async load (id) {
-      if (!id.match(svgRegex)) {
+      const regexResult = id.match(svgRegex);
+      if (! regexResult) {
         return
       }
 
-      const [path, query] = id.split('?', 2)
-
+      const [path] = id.split('?', 2)
+      const query = regexResult[2]
+      const parameter = regexResult[4]
+      
       const importType = query || defaultImport
 
       if (importType === 'url') {
@@ -37,8 +40,16 @@ module.exports = function svgLoader (options = {}) {
         return
       }
 
+      if (parameter){
+          svg = svg.replace(/<svg/, `<svg class="${parameter}" `)
+      }
+
       if (importType === 'raw') {
         return `export default ${JSON.stringify(svg)}`
+      }
+
+      if (importType === 'base64') {
+        return `export default ${JSON.stringify(btoa(svg))}`
       }
 
       if (svgo !== false && query !== 'skipsvgo') {


### PR DESCRIPTION
Refactored to regex, allowing me to : 
- add a base64 output option
- add an optional parameter to pass a custom class (for raw or base64 output), applied to the SVG element

Usage : 
```
./my-svg.svg?base64
./my-svg.svg?base64=customclass
./my-svg.svg?raw=customclass
```