### PR TITLE
Skip processing for Vite virtual resources

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = function svgLoader (options = {}) {
     enforce: 'pre',
 
     async load (id) {
-      if (!id.match(svgRegex)) {
+      if (id.startsWith("virtual:") || !id.match(svgRegex)) {
         return
       }
 


### PR DESCRIPTION
We can't process these, so skip them. Run the check prior to the regex match as it should be the quicker of the two operations.

Fixes #142 