### PR TITLE
feat: Add default slot support to SVG components

### DIFF
--- a/create-test-app.sh
+++ b/create-test-app.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Install dependencies of parent package first
+npm ci
+
 $1 # Install vue command, project name should be `test-app`
 
 # Copy example code and SVGs
@@ -20,5 +23,5 @@ fi
 # Install and build app
 cd ./test-app
 npm install
-npm install vite-svg-loader --save-dev
+npm install vite-svg-loader@file:../ --save-dev
 npm run build

--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -70,4 +70,14 @@ describe('Vite SVG Loader', () => {
   it('it send path to svgo', () => {
     cy.get('#component svg .test_svg__rectangle').should('exist')
   })
+
+  it('renders slot content inside svg element', () => {
+    cy.get('#with-slot svg')
+      .should('exist')
+      .within(() => {
+        cy.get('rect').should('exist')
+        cy.get('title').contains('Custom SVG Title')
+        cy.get('desc').contains('Custom SVG Description')
+      })
+  })
 })

--- a/example/src/App.vue
+++ b/example/src/App.vue
@@ -45,5 +45,12 @@ const Async = defineAsyncComponent(() => import(`./assets/${name}.svg`))
     <img src="/root.svg" />
   </div>
 
+  <div id="with-slot">
+    <Test>
+      <title>Custom SVG Title</title>
+      <desc>Custom SVG Description</desc>
+    </Test>
+  </div>
+
   <HelloWorld msg="Hello Vue 3 + Vite" />
 </template>

--- a/index.js
+++ b/index.js
@@ -51,6 +51,9 @@ module.exports = function svgLoader (options = {}) {
       // To prevent compileTemplate from removing the style tag
       svg = svg.replace(/<style/g, '<component is="style"').replace(/<\/style/g, '</component')
 
+      // Insert <slot /> inside the svg element
+      svg = svg.replace(/<\/svg>/, '<slot /></svg>')
+
       const { code } = compileTemplate({
         id: JSON.stringify(id),
         source: svg,


### PR DESCRIPTION
This PR adds support for default slots in SVG components, allowing users to inject additional elements (e.g., `<title>`, `<desc>`) into loaded SVGs for improved accessibility and customization.

## Usage Example

```vue
<template>
  <SvgIcon>
    <!-- Slot content will be rendered inside the <svg> element -->
    <title>Icon Title</title>
    <desc>This is a custom description for accessibility</desc>
  </SvgIcon>
</template>

<script setup>
import SvgIcon from './assets/icon.svg'
</script>
```
